### PR TITLE
Add zooming capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ It seems that everybody (almost) is using vscode those days, I'm not (I'm using 
 ## Documentation
 For more information, please visit square/cubism's [home page](http://square.github.io/cubism/) and [wiki](https://github.com/square/cubism/wiki)
 
+Starting from `1.2.0` there is a new `zoom` api for `context`, as the name implies it allows to zoom on the horizon(s).
+In order to do so add something like this:
+
+```javascript
+    const z = d3.select("body").append("div")
+        .attr("class", "zoom");
+
+    context.zoom(function(start, end) {
+        console.log(`Doing a zoom from point ${start} to point ${end}`);
+        context.zoom().zoomTime(start, end);
+    }).render(z);
+```
+
+The core of the configuration is the function that you pass to `zoom()`, it takes 2 parameters: the start index and the end index of the zoom, it's not time based but pixel based.
+
+You can do pretty much anything you want in the zoom function like actually zooming or calling a different URL with a detailed analysis of the zoom time.
+There is a function in the `zoom` module that you can reuse for doing the actual zooming: `zoom().zoomTime()`, your source must be able to provide a fresh array of values to handle the zoom, see examples in the stock or random demo.
+
 
 ## Limitation
 Graphite, Cube and GangliaWeb have not been verified yet.

--- a/demo/random.html
+++ b/demo/random.html
@@ -94,6 +94,9 @@
         right: 0;
     }
 
+    .zoom{
+        z-index: 2;
+    }
     .line {
         background: #000;
         z-index: 2;
@@ -120,6 +123,13 @@
         .attr("class", "rule");
 
     context.rule().render(r);
+    const z = d3.select("body").append("div")
+        .attr("class", "zoom");
+
+    context.zoom(function(start, end) {
+        console.log(`Doing a zoom from point ${start} to point ${end}`);
+        context.zoom().zoomTime(start, end);
+    }).render(z);
 
     const h = d3.select("body").selectAll(".horizon")
         .data(d3.range(1, 50).map(random))
@@ -138,7 +148,11 @@
         var value = 0,
             values = [],
             i = 0,
-            last;
+            last, last_width = 0,
+            last_stop = null, last_step =0;
+
+        var metric_name = x;
+
         return context.metric(function(start, stop, step, callback) {
             start = +start, stop = +stop;
             if (isNaN(last)) last = start;
@@ -147,8 +161,35 @@
                 value = Math.max(-10, Math.min(10, value + .8 * Math.random() - .4 + .2 * Math.cos(i += x * .02)));
                 values.push(value);
             }
-            callback(null, values = values.slice((start - stop) / step));
-        }, x);
+            if (last_step == 0) {
+                last_width = (stop - start) / step;
+            }
+            if (last_step ==  0 || last_step == step) {
+                // first argument is the error, null indicates no error
+                callback(null, values.slice((start - stop) / step));
+            } else {
+                // calculate last_start relative to last stop, store witdth
+                last_start = last_stop - (last_step * last_width);
+                // get the last width / nb_points elements
+                var tmp = values.slice(-last_width);
+                var offset_start = (start - last_start) / last_step
+                var cur = start - step;
+                var offset = offset_start;
+                var old_cur = start;
+                var new_values = []
+                while (cur < stop) {
+                    while((cur = cur + step ) < old_cur && cur <= stop) new_values.push(tmp[offset  - 1])
+                    if (cur < stop) {
+                        new_values.push(tmp[offset])
+                        old_cur = old_cur + last_step;
+                        offset++;
+                    }
+                }
+                callback(null, new_values);
+            }
+            last_stop = stop;
+            last_step = step;
+        }, metric_name);
     }
 
 </script>

--- a/demo/stock.html
+++ b/demo/stock.html
@@ -109,7 +109,7 @@
     var delay = Date.now()  - new Date(2012, 4, 2)
     var context = cubism.context()
         .serverDelay(delay)
-        .step(864e5)
+        .step(864e5) // 86400 000 aka 86400 seconds
         .size(1280)
         .stop();
 
@@ -131,6 +131,14 @@
 
 
     context.horizon().format(d3.format("+,.2p")).render(d3.selectAll('.horizon'))
+    const z = d3.select("body").append("div")
+        .attr("class", "zoom");
+
+    context.zoom(function(start, end) {
+        console.log(`Doing a zoom from point ${start} to point ${end}`);
+        context.zoom().zoomTime(start, end);
+    }).render(z);
+
 
     context.on("focus", function(i) {
         d3.selectAll(".value").style("right", i == null ? null : context.size() - i + "px");
@@ -141,13 +149,25 @@
         var format = d3.timeParse("%d-%b-%y");
         return context.metric(function(start, stop, step, callback) {
             d3.csv("data/stocks/" + name + ".csv").then(rows => {
+                // read all the rows date the date and the open value, filter only for lines where
+                // there is data
                 rows = rows.map(function(d) { return [format(d.Date), +d.Open]; }).filter(function(d) { return d[1]; }).reverse();
-                var date = rows[0][0], compare = rows[400][1], value = rows[0][1], values = [value];
+                var date = rows[0][0], compare = rows[400][1], value = 0, values = [];
                 rows.forEach(function(d) {
-                    while ((date = d3.timeDay.offset(date, 1)) < d[0]) values.push(value);
-                    values.push(value = (d[1] - compare) / compare);
+                    if (d[0] >= start  && d[0] <= stop) {
+                        if (date < start) {
+                            console.log(`Forcing ${date} to ${start} end = ${stop} d[0] = ${d[0]} ${step/1000}`);
+                            date = start
+                        }
+                        while ((date = d3.timeMillisecond.offset(date, step )) < d[0]) { values.push(value);}
+                        values.push(value = (d[1] - compare) / compare);
+                    } else {
+                       date = d[0]
+                    }
                 });
-                callback(null, values.slice(-context.size()));
+                const desired_length = (stop -start)/step;
+                while (values.length < desired_length) values.push(value);
+                callback(null, values);
             });
         }, name);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cubism-es",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cubism-es",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "d3-axis": "2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cubism-es",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Cubism.js ES6 module, based on D3 V6 components",
   "main": "dist/cubism-es.js",
   "module": "dist/cubism-es.esm.js",

--- a/src/context/apiFocus.js
+++ b/src/context/apiFocus.js
@@ -1,6 +1,10 @@
 const apiFocus = (state) => ({
   focus: (i) => {
     const { _event } = state;
+    // will call for all the objects that have subscribe to the focus event
+    // the function associated with the value property the paremeter will be state._focus
+    // aka the x position
+
     _event.call('focus', state, (state._focus = i));
     return state;
   },

--- a/src/context/apiOn.js
+++ b/src/context/apiOn.js
@@ -3,11 +3,15 @@ const apiOn = (state) => ({
     const { _event, _focus, _start1, _stop1, _start0, _stop0 } = state;
     if (listener === null) return _event.on(type);
 
+    // register the listener (that is to say the callback)
+    // for the event
     _event.on(type, listener);
 
     // Notify the listener of the current start and stop time, as appropriate.
     // This way, metrics can make requests for data immediately,
     // and likewise the axis can display itself synchronously.
+    // Prepare is notifying the metrics objects (one per horizon) to do something like fetching data
+    // call the callback with the right parameter
     if (/^prepare(\.|$)/.test(type)) listener(_start1, _stop1);
     if (/^beforechange(\.|$)/.test(type)) listener(_start0, _stop0);
     if (/^change(\.|$)/.test(type)) listener(_start0, _stop0);

--- a/src/context/apiStart.js
+++ b/src/context/apiStart.js
@@ -12,6 +12,9 @@ const apiStart = (state) => ({
       _focus,
     } = state;
 
+    if (_timeout !== null && _timeout == -1) {
+      return state;
+    }
     if (_timeout) clearTimeout(_timeout);
     let delay = +_stop1 + _serverDelay - Date.now();
 
@@ -19,6 +22,10 @@ const apiStart = (state) => ({
     if (delay < _clientDelay) delay += _step;
 
     const prepare = () => {
+      const { _timeout } = state;
+      if (_timeout !== null && _timeout == -1) {
+        return state;
+      }
       state._stop1 = new Date(
         Math.floor((Date.now() - _serverDelay) / _step) * _step
       );

--- a/src/context/apiStep.js
+++ b/src/context/apiStep.js
@@ -1,6 +1,6 @@
 import update from './update';
 
-// Set or ge2t the step interval in milliseconds.
+// Set or get the step interval in milliseconds.
 // Defaults to ten seconds.
 const apiStep = (state) => ({
   step: (_step = null) => {

--- a/src/context/apiStop.js
+++ b/src/context/apiStop.js
@@ -1,6 +1,9 @@
 const apiStop = (state) => ({
   stop: () => {
-    state._timeout = clearTimeout(state._timeout);
+    if (state._timeout !== null && state._timeout !== -1) {
+      clearTimeout(state._timeout);
+      state._timeout = -1;
+    }
     return state;
   },
 });

--- a/src/context/apiZoom.js
+++ b/src/context/apiZoom.js
@@ -1,0 +1,188 @@
+const config = {
+  current_corner: null,
+};
+
+const apiStart = (zoomState) => ({
+  start: (selection, pos) => {
+    var x = Math.round(pos[0]);
+    var y = Math.round(pos[1]);
+    zoomState._corner1 = [x, y];
+  },
+});
+
+const apiReset = (zoomState) => ({
+  reset: () => {
+    zoomState._corner1 = null;
+  },
+});
+const apiStop = (zoomState) => ({
+  stop: (selection, pos) => {
+    var x = Math.round(pos[0]);
+    var y = Math.round(pos[1]);
+    zoomState._corner2 = [x, y];
+    // call the callback that was specified with the start and end point
+    // also context.scale has the time range we can get the timestamp by doing
+    // context.scale.invert(x)
+    if (zoomState._corner1 != null) {
+      var start = Math.min(zoomState._corner1[0], zoomState._corner2[0]);
+      var end = Math.max(zoomState._corner1[0], zoomState._corner2[0]);
+      if (start !== end) {
+        zoomState._callback(start, end);
+      } else {
+        console.log('Skipping zoom on 1 point');
+      }
+    }
+    // force the zoom indicator to hide
+    zoomState._corner1 = null;
+  },
+});
+
+const apiZoomTime = (zoomState) => ({
+  zoomTime: (start, stop) => {
+    const { _context } = zoomState;
+    const { _step } = _context;
+
+    if (_context._start_before_zoom === null) {
+      // save the original start and stop
+      _context._start_before_zoom = _context.start1;
+      _context._stop_before_zoom = _context.stop1;
+    }
+    var new_start_time = _context._scale.invert(start);
+    var new_end_time = _context._scale.invert(stop);
+    console.log('zoomTime() called');
+    console.log(`${new_start_time} ${new_end_time}`);
+
+    // stop the timeout
+    _context.stop();
+    var width = (new_end_time - new_start_time) / _context._size;
+
+    _context._step = width;
+
+    _context._start1 = new_start_time;
+    _context._stop1 = new_end_time;
+
+    // Fetch new data
+    _context._event.call('reset', _context);
+    _context._event.call(
+      'prepare',
+      _context,
+      _context._start1,
+      _context._stop1
+    );
+    _context._start0 = new_start_time;
+    _context._stop0 = new_end_time;
+
+    setTimeout(() => {
+      // delay calling change to deal with the prepare()
+      _context._scale.domain([_context._start1, _context._stop1]);
+      _context._event.call(
+        'change',
+        zoomState,
+        _context._start1,
+        _context._stop1
+      );
+      _context._event.call('focus', _context, _context._focus);
+    }, 500);
+  },
+});
+
+const apiRender = (zoomState) => ({
+  render: (selection) => {
+    const { _context } = zoomState;
+    const id = ++_context._id;
+
+    const frame = selection
+      .append('svg')
+      .datum({ id: id })
+      .attr('class', 'zoom')
+      .style('position', 'absolute')
+      .style('top', 0)
+      .style('bottom', 0);
+
+    const rectangle = frame.append('rect').attr('fill-opacity', '50%'); // 50% transparent
+
+    // All elements that register for events "focus.<something>" will be called when the horizon
+    // call context.focus()
+    _context.on('focus.zoom-' + id, (i) => {
+      if (zoomState._corner1 !== null) {
+        var x = Math.min(zoomState._corner1[0], zoomState._current_corner[0]);
+        var y = Math.min(zoomState._corner1[1], zoomState._current_corner[1]);
+        var width = Math.abs(
+          zoomState._corner1[0] - zoomState._current_corner[0]
+        );
+        var height = Math.abs(
+          zoomState._corner1[1] - zoomState._current_corner[1]
+        );
+
+        // set the dimensions the rectangle
+        rectangle.attr('width', width);
+        rectangle.attr('height', height);
+
+        // parent element control where the rectangle will be shown
+        frame
+          .style('left', `${x}px`)
+          .style('top', `${y}px`)
+          .style('width', `${width}px`)
+          .style('height', `${height}px`)
+          .style('display', 'block');
+      } else {
+        frame.style('display', 'none');
+      }
+    });
+    return zoomState;
+  },
+});
+
+const apiEnabled = (zoomState) => ({
+  enabled: () => {
+    const { _enabled } = zoomState;
+    return _enabled;
+  },
+});
+
+const apiUpdateCurrentCorner = (zoomState) => ({
+  updateCurrentCorner: (pos) => {
+    // can't use { _current_corner } as it's the value not the address / object
+    zoomState._current_corner = [Math.round(pos[0]), Math.round(pos[1])];
+  },
+});
+
+const apiZoom = (context) => ({
+  zoom: (callback) => {
+    const { _zoom } = context;
+    if (_zoom !== null) {
+      if (callback !== null && callback !== undefined) {
+        context._zoom._enabled = true;
+        context._zoom._callback = callback;
+        return context._zoom;
+      }
+      return _zoom;
+    }
+    var enabled = true;
+    if (callback === null || callback == undefined) {
+      enabled = false;
+    }
+    const state = {
+      _context: context,
+      _enabled: enabled,
+      _callback: callback,
+      _current_corner: null,
+      _corner1: null, // the first corner of selection when you press the mouse
+      _corner2: null, // the second corner of selection when you release the mouse
+    };
+
+    var obj = Object.assign(
+      state,
+      apiStart(state),
+      apiStop(state),
+      apiReset(state),
+      apiRender(state),
+      apiEnabled(state),
+      apiUpdateCurrentCorner(state),
+      apiZoomTime(state)
+    );
+    context._zoom = obj;
+    return obj;
+  },
+});
+export default apiZoom;

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -9,6 +9,7 @@ import apiClientDelay from './apiClientDelay';
 import apiServerDelay from './apiServerDelay';
 import apiSize from './apiSize';
 import apiStep from './apiStep';
+import apiZoom from './apiZoom';
 import update from './update';
 
 import apiMetric from '../metric';
@@ -29,13 +30,16 @@ const context = () => {
     _size: 1440, // ten seconds, in milliseconds
     _serverDelay: 5e3,
     _clientDelay: 5e3,
-    _event: dispatch('prepare', 'beforechange', 'change', 'focus'),
+    _event: dispatch('prepare', 'beforechange', 'change', 'focus', 'reset'),
     _start0: null,
     _stop0: null, // the start and stop for the previous change event
     _start1: null,
     _stop1: null, // the start and stop for the next prepare event
+    _start_before_zoom: null,
+    _stop_before_zoom: null,
     _timeout: null,
     _focus: null,
+    _zoom: null,
     _scale: scaleTime().range([0, 1440]),
   };
 
@@ -53,7 +57,8 @@ const context = () => {
     apiSize(state),
     apiStart(state),
     apiStop(state),
-    apiStep(state)
+    apiStep(state),
+    apiZoom(state)
   );
 
   state._timeout = setTimeout(_context.start, 10);

--- a/src/metric/apiOn.js
+++ b/src/metric/apiOn.js
@@ -14,6 +14,11 @@ const beforechange = (state) => (start1, stop1) => {
 // how much refetch if there is a lag
 const metric_overlap = 6;
 
+const reset = (state) => () => {
+  state._start = -Infinity;
+  state.value = [];
+};
+
 // Prefetch new data into a temporary array.
 const prepare = (state, request) => (start1, stop) => {
   const { _start, _step, _fetching, _event, _size } = state;
@@ -46,6 +51,7 @@ const apiOn = (state, request) => ({
     } else {
       if (_event.on(type) == null && ++state._listening === 1) {
         context
+          .on('reset' + _id, reset(state))
           .on('prepare' + _id, prepare(state, request))
           .on('beforechange' + _id, beforechange(state));
       }


### PR DESCRIPTION
This should address the issue in https://github.com/BigFatDog/cubism-es/issues/9.

There is two part in the change itself one to allow the user to interact
with the graph to indicate wich area of the graph should be zoomed and
one to actually to allow redrawing the graph with zoomed data.

The data model for cubism didn't map very well with the later, metrics
are meant to be appended on and on and not rewind back in time a replot
new (more detailed metrics).

So this required a bit more change.

In order to use it add this in the code:
```
    const z = d3.select("body").append("div")
        .attr("class", "zoom");
    context.zoom(function(start, end) {
        console.log(`Doing a zoom from point ${start} to point ${end}`);
        context.zoom().zoomTime(start, end);
    }).render(z);
```
