### PR TITLE
Do not display value(s) that are null

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,3 @@
-* Fix display so that we don't NaN when there is no value it's not really adding much value.
+~~* Fix display so that we don't NaN when there is no value it's not really adding much value.~~
 ~~* Add a way to disable keypress~~
 * Most of d3 is still included because all the d3 submodules are not marked as external in `rollup`

--- a/demo/simple.html
+++ b/demo/simple.html
@@ -234,6 +234,7 @@
 </style>
 <div id="body">
     <div id="example2a"></div>
+    <div id="example2c"></div>
 </div>
 
 <script src="lib/d3.v7.min.js" charset="utf-8"></script>
@@ -241,7 +242,7 @@
 <script src="./cubism-es.standalone.js"></script>
 <script>
 
-    function random(name) {
+    function random(name, addNull=false) {
         var value = 0,
             values = [],
             i = 0,
@@ -253,6 +254,9 @@
                 last += step;
                 value = Math.max(-10, Math.min(10, value + .8 * Math.random() - .4 + .2 * Math.cos(i += .2)));
                 values.push(value);
+            }
+            if (addNull) {
+                values.push(null)
             }
 
             callback(null, values = values.slice((start - stop) / step));
@@ -270,6 +274,7 @@
 
     var foo = random("foo"),
         bar = random("bar");
+        baz = random("baz", true);
 
     // console.log(foo.add(bar));
     // console.log(foo.subtract(bar));
@@ -316,6 +321,25 @@
 
         context.horizon()
             .height(80)
+            .mode("mirror")
+            .colors(["#bdd7e7","#bae4b3"])
+            .title("Area (80px)")
+            .extent([-10, 10])
+            .render(b);
+    });
+    var context2 = cubism.context()
+        .serverDelay(0)
+        .clientDelay(0)
+        .step(1e3)
+        .size(960).
+        stop();
+    d3.select("#example2c").call(function(div) {
+        div.datum(baz);
+        const b = div.append("div")
+            .attr("class", "horizon");
+
+        context2.horizon()
+            .height(30)
             .mode("mirror")
             .colors(["#bdd7e7","#bae4b3"])
             .title("Area (30px)")
@@ -369,6 +393,9 @@
 
     // On mousemove, reposition the chart values to match the rule.
     context.on("focus", function(i) {
+        d3.selectAll(".value").style("right", i == null ? null : context.size() - i + "px");
+    });
+    context2.on("focus", function(i) {
         d3.selectAll(".value").style("right", i == null ? null : context.size() - i + "px");
     });
 

--- a/src/horizon/apiRender.js
+++ b/src/horizon/apiRender.js
@@ -3,7 +3,6 @@ import * as d3 from 'd3';
 
 const apiRender = (context, state) => ({
   render: (selection) => {
-    selection.append('div').attr('a', 'b');
     const {
       _width,
       _height,
@@ -177,7 +176,11 @@ const apiRender = (context, state) => ({
 
       const focus = (i) => {
         if (i == null) i = _width - 1;
-        const value = metric_.valueAt(i);
+        var value = metric_.valueAt(i);
+        // strangely enough null is a value ... in some way
+        if (value === null) {
+          value = undefined;
+        }
         span.datum(value).text(isNaN(value) ? null : _format);
       };
 

--- a/src/tests/horizon.test.ts
+++ b/src/tests/horizon.test.ts
@@ -6,6 +6,9 @@ describe('horizon', () => {
   let hz;
   var cubismContext;
   let h;
+  afterEach(() => {
+    jest.useRealTimers();
+  });
   beforeEach(() => {
     document.body.innerHTML = '<div id="demo"></div>';
     cubismContext = context().step(1e4).size(10);
@@ -89,10 +92,42 @@ describe('horizon', () => {
     hz.colors(['#112233', '#AABBCC']);
     expect(hz.colors()).toStrictEqual(['#112233', '#AABBCC']);
   });
-  it('works when calling colors() with arg', () => {
+  it('works when calling remove() with arg', () => {
     hz.remove(h);
     expect(document.body.innerHTML).toBe(
-      '<div id="demo"><div class="horizon"><div a="b"></div></div><div class="horizon"><div a="b"></div></div></div>'
+      '<div id="demo"><div class="horizon"></div><div class="horizon"></div></div>'
+    );
+  });
+  it('works when the value is null', () => {
+    jest.useFakeTimers();
+    document.body.innerHTML = '<div id="demo"></div>';
+    var thisContext = context()
+      .step(1e3)
+      .size(10)
+      .serverDelay(0)
+      .clientDelay(0);
+    const getData = (i) => {
+      return thisContext.metric(
+        function (start, stop, step, callback) {
+          let values = [1, 2, 3, 4, 5, 6, 7, 8, 9, i == 2 ? null : 10];
+          callback(null, values);
+        },
+        'serie ' + (i + 1)
+      );
+    };
+
+    h = d3
+      .select('#demo')
+      .selectAll('.horizon')
+      .data(d3.range(1, 3).map(getData))
+      .enter()
+      .insert('div', '.bottom')
+      .attr('class', 'horizon');
+    hz = thisContext.horizon();
+    hz.render(h);
+
+    expect(document.body.innerHTML).toBe(
+      '<div id="demo"><div class="horizon"><canvas width="10" height="30"></canvas><span class="title">serie 2</span><span class="value">10</span></div><div class="horizon"><canvas width="10" height="30"></canvas><span class="title">serie 3</span><span class="value"></span></div></div>'
     );
   });
 });


### PR DESCRIPTION
In theory there is provision not to display values that are not a number
because there is a test `isNaN(value)? "": _format` but it seems that
null is a number and so `NaN` is displayed.

I changed `simple.html` to have the last value be null and also removed
a div that seems not to be needed
