### PR TITLE
Allow other to control how they import `cubism-es`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ The core of the configuration is the function that you pass to `zoom()`, it take
 You can do pretty much anything you want in the zoom function like actually zooming or calling a different URL with a detailed analysis of the zoom time.
 There is a function in the `zoom` module that you can reuse for doing the actual zooming: `zoom().zoomTime()`, your source must be able to provide a fresh array of values to handle the zoom, see examples in the stock or random demo.
 
+Zoom also support a zoom style or zoom type, the default one is drawing a rectangle from the point where you click and to the point where you are moving your mouse, `onelane` will start at the top of the horizon that has been clicked and will go to the bottom of this horizon; `full` will start at the top of the whole `cubism` graph till the bottom of it.
+
 
 ## Limitation
 Graphite, Cube and GangliaWeb have not been verified yet.

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,4 @@
 ~~* Fix display so that we don't NaN when there is no value it's not really adding much value.~~
 ~~* Add a way to disable keypress~~
 * Most of d3 is still included because all the d3 submodules are not marked as external in `rollup`
+* Properly record all the timeouts so that `stop()` actually stopping everything

--- a/cypress/e2e/e2e.cy.js
+++ b/cypress/e2e/e2e.cy.js
@@ -271,24 +271,24 @@ describe('Stock Check Test With Zoom', function () {
     cy.get('div.horizon')
       .first()
       .then(($div) => {
-        cy.get('body').trigger('mousemove', 10, 0);
+        cy.get('body').trigger('mousemove', 10, 70);
         cy.get('body').trigger('mousedown', {
           eventConstructor: 'MouseEvent',
           button: 0,
           clientX: 10,
-          clientY: 0,
+          clientY: 70,
         });
         cy.wait(200);
         cy.get('body').trigger('mousemove', {
           eventConstructor: 'MouseEvent',
           clientX: 300,
-          clientY: 10,
+          clientY: 80,
         });
         cy.wait(200);
         cy.get('body').trigger('mouseup', {
           eventConstructor: 'MouseEvent',
           clientX: 300,
-          clientY: 10,
+          clientY: 80,
         });
         // Deal with the delay in rendering after zooming
         cy.wait(600);
@@ -299,7 +299,7 @@ describe('Stock Check Test With Zoom', function () {
           .first()
           .then(($div) => {
             const divOffset = $div.offset();
-            cy.get('body').trigger('mousemove', 10, 0);
+            cy.get('body').trigger('mousemove', 10, 70);
           });
         cy.get('#rule')
           .find('div.line')

--- a/demo/stock.html
+++ b/demo/stock.html
@@ -6,7 +6,11 @@
         font-family: "Helvetica Neue", Helvetica, sans-serif;
         margin: 30px auto;
         width: 1280px;
+    }
+
+    #demo {
         position: relative;
+        overflow: hidden;
     }
 
     header {
@@ -43,7 +47,6 @@
         background-image: -moz-linear-gradient(top, #fff 0%, rgba(255,255,255,0) 100%);
         background-image: -webkit-linear-gradient(top, #fff 0%, rgba(255,255,255,0) 100%);
         background-image: -ms-linear-gradient(top, #fff 0%, rgba(255,255,255,0) 100%);
-        top: 0px;
         padding: 0 0 24px 0;
     }
 
@@ -53,7 +56,6 @@
         background-image: -moz-linear-gradient(bottom, #fff 0%, rgba(255,255,255,0) 100%);
         background-image: -webkit-linear-gradient(bottom, #fff 0%, rgba(255,255,255,0) 100%);
         background-image: -ms-linear-gradient(bottom, #fff 0%, rgba(255,255,255,0) 100%);
-        bottom: 0px;
         padding: 24px 0 0 0;
     }
 
@@ -95,15 +97,21 @@
     }
 
     .line {
+        position: relative;
         background: #000;
         z-index: 2;
+    }
+
+    .rule {
     }
 
 </style>
 <script src="lib/d3.v7.min.js" charset="utf-8"></script>
 <!--<script src="https://cdnjs.cloudflare.com/ajax/libs/es6-shim/0.35.3/es6-shim.js"></script>-->
 <script src="./cubism-es.standalone.js"></script>
-<body id="demo">
+<body>
+<H1> Stock Demo</H1>
+<div id="demo">
 <script>
 
     var delay = Date.now()  - new Date(2012, 4, 2)
@@ -114,30 +122,30 @@
         .size(size)
         .stop();
 
-    d3.select("#demo").selectAll(".axis")
-        .data(['top', "bottom"])
-        .enter().append("div")
-        .attr("class", function(d) { return d + " axis"; })
-        .each(function(d) { context.axis().ticks(12).orient(d).render(d3.select(this)) });
 
-    const d = d3.select("body").append("div")
-        .attr("class", "rule")
-        .attr('id', 'rule');
-    context.rule().render(d);
 
-    d3.select("body").selectAll(".horizon")
+    d3.select("#demo").selectAll(".horizon")
         .data(["AAPL", "BIDU", "SINA", "GOOG", "MSFT", "YHOO", "ADBE", "REDF", "INSP", "IACI", "AVID", "CCUR", "DELL", "DGII", "HPQ", "SGI", "SMCI", "SNDK", "SYNA"].map(stock))
         .enter().insert("div", ".bottom")
         .attr("class", "horizon");
 
 
     context.horizon().format(d3.format("+,.2p")).render(d3.selectAll('.horizon'))
-    const z = d3.select("body").append("div")
+    const z = d3.select("#demo").append("div")
         .attr("class", "zoom");
+    const d = d3.select("#demo").append("div")
+        .attr("class", "rule")
+        .attr('id', 'rule');
+    context.rule().render(d);
+    d3.select("#demo").selectAll(".axis")
+        .data(['top', "bottom"])
+        .enter().append("div")
+        .attr("class", function(d) { return d + " axis"; })
+        .each(function(d) { context.axis().ticks(12).orient(d).render(d3.select(this)) });
 
-    context.zoom(function(start, end) {
+    context.zoom(function(start, end, selection) {
         console.log(`Doing a zoom from point ${start} to point ${end}`);
-        context.zoom().zoomTime(start, end);
+        context.zoom().zoomTime(start, end, selection);
     }).render(z);
 
 
@@ -174,4 +182,6 @@
     }
 
 </script>
-
+</div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
     "all": true,
     "report-dir": "coverage/cypress"
   },
+  "exports": {
+    ".": "dist/cubism-es.js",
+    "./esm/cubism-es.esm.js": "dist/cubism-es.esm.js"
+  },
   "dependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@testing-library/jest-dom": "^6.4.2",

--- a/src/horizon/apiRender.js
+++ b/src/horizon/apiRender.js
@@ -22,11 +22,8 @@ const apiRender = (context, state) => ({
       .on('mousemove.horizon', function (event) {
         context.focus(Math.round(d3.pointer(event)[0]));
         if (context.zoom().enabled()) {
-          context
-            .zoom()
-            .updateCurrentCorner(
-              d3.pointer(event, selection.node().parentNode)
-            );
+          var position = d3.pointer(event, selection.node().parentNode);
+          context.zoom().updateCurrentCorner(position, selection);
         }
       })
       .on('mouseout.horizon', () => {
@@ -43,13 +40,15 @@ const apiRender = (context, state) => ({
     selection
       .on('mousedown', (event) => {
         if (context.zoom().enabled()) {
-          console.log('zoom called');
-          zoom.start(selection, d3.pointer(event, selection.node().parentNode));
+          var current_node = event.target;
+          var position = d3.pointer(event, selection.node().parentNode);
+          zoom.start(d3.select(current_node.parentNode), position);
         }
       })
       .on('mouseup', (event) => {
         if (context.zoom().enabled()) {
-          zoom.stop(selection, d3.pointer(event, selection.node().parentNode));
+          var position = d3.pointer(event, selection.node().parentNode);
+          zoom.stop(position);
           context.focus(Math.round(d3.pointer(event)[0]));
         }
       });

--- a/src/tests/context.test.ts
+++ b/src/tests/context.test.ts
@@ -42,6 +42,46 @@ describe('apiCSS', () => {
 });
 
 describe('apiZoom', () => {
+  it('should work when mode is full', () => {
+    const createMockSelection = () => {
+      const parent = { offsetTop: 72, clientHeight: 7 };
+      const selection = {
+        node: jest.fn().mockReturnValue({
+          parentNode: parent,
+          clientHeight: 5,
+          offsetTop: 56,
+        }),
+      };
+      return selection;
+    };
+    let sel = createMockSelection();
+    let cubismContext = context();
+    cubismContext.zoom().setZoomType('full');
+    cubismContext.zoom().start(sel, [12, 5]);
+    expect(cubismContext._zoom.getFirstCorner()).toStrictEqual([12, 72]);
+    cubismContext.zoom().updateCurrentCorner([24, 10], sel);
+    expect(cubismContext._zoom.getCurrentCorner()).toStrictEqual([24, 79]);
+  });
+  it('should work when mode is onelane', () => {
+    const createMockSelection = () => {
+      const parent = { offsetTop: 72, clientHeight: 7 };
+      const selection = {
+        node: jest.fn().mockReturnValue({
+          parentNode: parent,
+          clientHeight: 5,
+          offsetTop: 56,
+        }),
+      };
+      return selection;
+    };
+    let sel = createMockSelection();
+    let cubismContext = context();
+    cubismContext.zoom().setZoomType('onelane');
+    cubismContext.zoom().start(sel, [12, 5]);
+    expect(cubismContext._zoom.getFirstCorner()).toStrictEqual([12, 56]);
+    cubismContext.zoom().updateCurrentCorner([24, 10], sel);
+    expect(cubismContext._zoom.getCurrentCorner()).toStrictEqual([24, 61]);
+  });
   it('should store the position correctly when start is called', () => {
     let cubismContext = context();
     cubismContext.zoom().start(null, [12, 5]);
@@ -64,7 +104,7 @@ describe('apiZoom', () => {
     cubismContext._start1 = 100;
     cubismContext.zoom().start(null, [12, 5]);
     expect(cubismContext._zoom.getFirstCorner()).toStrictEqual([12, 5]);
-    cubismContext.zoom().stop(null, [24, 7]);
+    cubismContext.zoom().stop([24, 7]);
     expect(cubismContext._zoom.getFirstCorner()).toBe(null);
     expect(cubismContext._zoom.getSecondCorner()).toStrictEqual([24, 7]);
   });
@@ -77,7 +117,7 @@ describe('apiZoom', () => {
     cubismContext._start1 = 1;
     cubismContext._start1 = 100;
     cubismContext.zoom().start(null, [24, 5]);
-    cubismContext.zoom().stop(null, [12, 7]);
+    cubismContext.zoom().stop([12, 7]);
     expect(cubismContext._zoom.getFirstCorner()).toBe(null);
   });
   it('should not call the callback in stop() if it is the same point', () => {
@@ -91,9 +131,22 @@ describe('apiZoom', () => {
     cubismContext._start1 = 1;
     cubismContext._start1 = 100;
     cubismContext.zoom().start(null, [24, 5]);
-    cubismContext.zoom().stop(null, [24, 7]);
+    cubismContext.zoom().stop([24, 7]);
     expect(cubismContext._zoom.getFirstCorner()).toBe(null);
     expect(called).toBe(false);
+  });
+  it('should work when calling getZoomType', () => {
+    let cubismContext = context();
+    let called = false;
+    cubismContext.zoom((start: number, end: number) => {});
+    expect(cubismContext.zoom().getZoomType()).toBe('default');
+  });
+  it('should work when calling setZoomType', () => {
+    let cubismContext = context();
+    let called = false;
+    cubismContext.zoom((start: number, end: number) => {});
+    cubismContext.zoom().setZoomType('full');
+    expect(cubismContext.zoom().getZoomType()).toBe('full');
   });
 });
 


### PR DESCRIPTION
We build multiple things:
* a CJS "module"
* a ES module
* a JS standalone file (mostly for testing but it might be useful for
  someone else).

But there was no control on how it was imported when using NodeJS, which
mean that it's almost certain that it's the CJS file that will be used.

This seems to work most of the time but somehow when `cubism-es` is used
elsewhere and you want to test it using jest there is an issue with d3
global variable. If I try to `require` `d3` in `jest-setup.js` then

```
import * as cubism from `cubism-es`
```

Is not quite working because cubism is just an empty object.
So instead with the new export we can import the `ESM` version of
`cubism-es` and avoid the issue with the global variable.
