### PR TITLE
Remove the exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,6 @@
     "all": true,
     "report-dir": "coverage/cypress"
   },
-  "exports": {
-    ".": "dist/cubism-es.js",
-    "./esm/cubism-es.esm.js": "dist/cubism-es.esm.js"
-  },
   "dependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@testing-library/jest-dom": "^6.4.2",


### PR DESCRIPTION
It seems to hurt more than it helps and I found another way to make
things properly work in `jest`:

```
   globals: {
     'ts-jest': {
      // put other options there
      useESM: true,
     },
   },
   moduleNameMapper: {
     '^cubism-es$': path.resolve(__dirname, 'node_modules', 'cubism-es', 'dist', 'cubism-es.esm.js'),
   },
```
