### PR TITLE
Increase test coverage for context and comparison

### DIFF
--- a/src/comparison/apiMisc.js
+++ b/src/comparison/apiMisc.js
@@ -6,7 +6,7 @@ const apiMisc = (state) => ({
   },
   primary: (_ = null) => {
     if (_ === null) return state._primary;
-    state._primary = primary;
+    state._primary = _;
     return state;
   },
   secondary: (_ = null) => {
@@ -41,7 +41,7 @@ const apiMisc = (state) => ({
   },
   colors: (_ = null) => {
     if (_ === null) return state._colors;
-    state._colorscolors = _;
+    state._colors = _;
     return state;
   },
   strokeWidth: (_ = null) => {

--- a/src/context/apiStart.js
+++ b/src/context/apiStart.js
@@ -41,10 +41,10 @@ const apiStart = (state) => ({
         _event.call('focus', state, _focus);
       }, _clientDelay);
 
-      state.timeout = setTimeout(prepare, _step);
+        state._timeout = setTimeout(prepare, _step);
     };
 
-    state.timeout = setTimeout(prepare, delay);
+    state._timeout = setTimeout(prepare, delay);
 
     return state;
   },

--- a/src/tests/comparison.test.ts
+++ b/src/tests/comparison.test.ts
@@ -1,0 +1,41 @@
+import context from '../context';
+import * as d3 from 'd3';
+
+describe('comparison component', () => {
+  const createMetric = (values: number[]) => ({
+    extent: () => {
+      const min = Math.min(...values);
+      const max = Math.max(...values);
+      return [min, max];
+    },
+    valueAt: (i: number) => values[i],
+    on: jest.fn(),
+  });
+
+  test('misc setters update internal values', () => {
+    const ctx = context().size(5);
+    const cmp = ctx.comparison();
+    cmp.height(50);
+    cmp.strokeWidth(3);
+    const cols = ['a', 'b'];
+    cmp.colors(cols);
+    expect(cmp.height()).toBe(50);
+    expect(cmp.strokeWidth()).toBe(3);
+    expect(cmp.colors()).toBe(cols);
+  });
+
+  test('render and remove manipulate DOM', () => {
+    document.body.innerHTML = '<div id="wrap"></div>';
+    const ctx = context().size(5);
+    const cmp = ctx.comparison();
+    const m1 = createMetric([1, 2, 3, 4, 5]);
+    const m2 = createMetric([5, 4, 3, 2, 1]);
+    const sel = d3.select('#wrap').append('div').datum([m1, m2]);
+    cmp.render(sel);
+    expect(document.querySelectorAll('canvas').length).toBe(1);
+    expect(document.querySelectorAll('span').length).toBe(3);
+    cmp.remove(sel);
+    expect(document.querySelectorAll('canvas').length).toBe(0);
+    expect(document.querySelectorAll('span').length).toBe(0);
+  });
+});

--- a/src/tests/context_extras.test.ts
+++ b/src/tests/context_extras.test.ts
@@ -1,0 +1,36 @@
+import context from '../context';
+import * as d3 from 'd3';
+
+describe('additional context APIs', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('size updates internal scale', () => {
+    const ctx = context();
+    ctx.size(200);
+    expect(ctx.size()).toBe(200);
+    expect(ctx._scale.range()).toEqual([0, 200]);
+  });
+
+  test('step and serverDelay setters', () => {
+    const ctx = context();
+    ctx.step(5000);
+    ctx.serverDelay(2000);
+    expect(ctx.step()).toBe(5000);
+    expect(ctx.serverDelay()).toBe(2000);
+  });
+
+  test('start and stop manage timeout flag', () => {
+    const ctx = context();
+    ctx.stop();
+    expect(ctx._timeout).toBe(-1);
+    ctx.start();
+    expect(ctx._timeout).not.toBe(-1);
+    ctx.stop();
+    expect(ctx._timeout).toBe(-1);
+  });
+});


### PR DESCRIPTION
## Summary
- fix timeouts in apiStart
- correct setters in comparison apiMisc
- add tests for context utilities
- add tests for comparison component

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684512fa5aa4832c81f53c95bf2a79c6